### PR TITLE
Exposed functions to add support for editor extensions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,9 @@ export declare function getComponentFiles(
  * Replicate component given by `originialPath` into component with name `answers.name`
  * in folder `answers.folder`.
  *
+ * `originalPath` should point to the component file itself. Test, styles, etc. will also
+ * be copied automatically.
+ *
  * @param originalPath Path of the component to replicate.
  * @param answers An object containing `name` and `folder` of the new component.
  * @param workingDir (Optional) Current working directory

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,16 +4,36 @@ type InquirerFile = {
   value: string;
 };
 
-export declare function getComponentName(path: string): string
+/**
+ * Get the folder of a component at `path`.
+ *
+ * @param path Path to a component.
+ * @return The folder of the component given at `path`.
+ */
 export declare function getComponentFolder(path: string): string
-export declare function isSingleFile(path: string): boolean
-export declare function getFiles(cwd: string, componentName?: string): string[]
+
+/**
+ * Search for React components in directory `root`.
+ *
+ * @param root Directory to use as root.
+ * @param workingDir (Optional) Directory the command is executed from (used for relative paths).
+ * @return A promise resolving to an array of objects containing information about found components.
+ */
 export declare function getComponentFiles(
   root: string,
   workingDir?: string,
 ): Promise<InquirerFile[]>
+
+/**
+ * Replicate component given by `originialPath` into component with name `answers.name`
+ * in folder `answers.folder`.
+ *
+ * @param originalPath Path of the component to replicate.
+ * @param answers An object containing `name` and `folder` of the new component.
+ * @param workingDir (Optional) Current working directory
+ */
 export declare function performReplication(
-  path: string,
+  originalPath: string,
   answers: { name: string; folder: string },
   workingDir?: string,
 ): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,19 @@
+type InquirerFile = {
+  name: string;
+  short: string;
+  value: string;
+};
+
+export declare function getComponentName(path: string): string
+export declare function getComponentFolder(path: string): string
+export declare function isSingleFile(path: string): boolean
+export declare function getFiles(cwd: string, componentName?: string): string[]
+export declare function getComponentFiles(
+  root: string,
+  workingDir?: string,
+): Promise<InquirerFile[]>
+export declare function performReplication(
+  path: string,
+  answers: { name: string; folder: string },
+  workingDir?: string,
+): Promise<void>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/utils')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generact",
-  "version": "0.2.0",
+  "version": "0.2.4",
   "description": "Tool for generating React components by replicating your own components",
   "license": "MIT",
   "repository": "diegohaz/generact",
@@ -9,6 +9,8 @@
     "email": "hazdiego@gmail.com",
     "url": "github.com/diegohaz"
   },
+  "main": "./index.js",
+  "types": "./index.d.ts",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "email": "hazdiego@gmail.com",
     "url": "github.com/diegohaz"
   },
-  "main": "./index.js",
-  "types": "./index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "generact": "dist/cli.js"
   },
   "files": [
+    "index.js",
+    "index.d.ts",
     "dist"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generact",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Tool for generating React components by replicating your own components",
   "license": "MIT",
   "repository": "diegohaz/generact",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "minor": "npm version minor && npm publish",
     "major": "npm version major && npm publish",
     "prepublish": "npm run lint && npm test && npm run build",
-    "postpublish": "git push origin master --follow-tags"
+    "postpublish": "git push origin master --follow-tags",
+    "prepare": "npm run build"
   },
   "watch": {
     "test": "{src,test}/*.js",


### PR DESCRIPTION
- moved actual replication step of [replicate](https://github.com/diegohaz/generact/blob/v0.2.0/src/cli.js) into separate function in `utils.js`
- added option to pass in the `current working directory` for some of the util functions (because process.cwd() doesn't work for vscode extensions)
- exposed `utils.js` so that its functions can be used by other modules
- added typescript definition file for those functions (only the ones i used in vscode-generact)