### PR TITLE
Alternative pattern for matching local imports

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ export const replaceContents = (
   oldName: string,
   newName: string
 ): string => contents.replace(
-  new RegExp(`([^a-zA-Z0-9_$])${oldName}([^a-zA-Z0-9_$]|Container)|('./[a-zA-Z0-9_$]*?)${oldName}([a-zA-Z0-9_$]*?)`, 'g'),
+  new RegExp(`([^a-zA-Z0-9_$])${oldName}([^a-zA-Z0-9_$]|Container)|(['|"]./[a-zA-Z0-9_$]*?)${oldName}([a-zA-Z0-9_$]*?)`, 'g'),
   `$1$3${newName}$2$4`
 )
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -66,8 +66,8 @@ export const replaceContents = (
   oldName: string,
   newName: string
 ): string => contents.replace(
-  new RegExp(`([^a-zA-Z0-9_$])${oldName}([^a-zA-Z0-9_$]|Container)`, 'g'),
-  `$1${newName}$2`
+  new RegExp(`([^a-zA-Z0-9_$])${oldName}([^a-zA-Z0-9_$]|Container)|('./[a-zA-Z0-9_$]*?)${oldName}([a-zA-Z0-9_$]*?)`, 'g'),
+  `$1$3${newName}$2$4`
 )
 
 export const replicate = async (

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -85,15 +85,25 @@ test('getComponentFiles', async () => {
 test('replaceContents', () => {
   const contents = `
     import './Button.css'
+    import ButtonComponent from '../ButtonComponent'
+    import NodeButtonComponent from 'node-button-component'
+    import NodeYellowButtonComponent from 'node-component/YellowButton'
     import SimpleButton from './SimpleButton'
+    import { someButtonUtil } from './SimpleButtonUtils'
     const Button = () => <button />
+    export const someButtonUtil = () => {}
     export default Button
   `
 
   expect(replaceContents(contents, 'Button', 'AnotherButton')).toBe(`
     import './AnotherButton.css'
-    import SimpleButton from './SimpleButton'
+    import ButtonComponent from '../ButtonComponent'
+    import NodeButtonComponent from 'node-button-component'
+    import NodeYellowButtonComponent from 'node-component/YellowButton'
+    import SimpleButton from './SimpleAnotherButton'
+    import { someButtonUtil } from './SimpleAnotherButtonUtils'
     const AnotherButton = () => <button />
+    export const someButtonUtil = () => {}
     export default AnotherButton
   `)
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -90,6 +90,7 @@ test('replaceContents', () => {
     import NodeYellowButtonComponent from 'node-component/YellowButton'
     import SimpleButton from './SimpleButton'
     import { someButtonUtil } from './SimpleButtonUtils'
+    import { someButtonUtil } from "./SimpleButtonUtils";
     const Button = () => <button />
     export const someButtonUtil = () => {}
     export default Button
@@ -102,6 +103,7 @@ test('replaceContents', () => {
     import NodeYellowButtonComponent from 'node-component/YellowButton'
     import SimpleButton from './SimpleAnotherButton'
     import { someButtonUtil } from './SimpleAnotherButtonUtils'
+    import { someButtonUtil } from "./SimpleAnotherButtonUtils";
     const AnotherButton = () => <button />
     export const someButtonUtil = () => {}
     export default AnotherButton


### PR DESCRIPTION
Closes #14 

Hi, I've managed some time to try to solve your issue, hope will be useful :)

Current solution is far from being perfect, nonetheless as alternative, matches local imports in one `.replace()` cycle and passes assumed tests.

Drawbacks:
- current `master` code badly matches in dependency import (previously reported in issue),
```
    -    import NodeButtonComponent from 'node-component/lib/Button'
    +    import NodeButtonComponent from 'node-component/lib/AnotherButton'
```

- the naming of import is not changing, IMO it's 'ok' as fair as we are not replacing inherited imports usage (eg. `<SimpleButton>` in code is not replacing currently)
```
    -    import SimpleAnotherButton from './SimpleAnotherButton'
    +    import SimpleButton from './SimpleAnotherButton'
```

There is possibility for making it more readable/customisable by running multiple `.replace()`, but it would suffer from performance penalty and unexpected overwriting.

Let me know about your thoughts on my contribution, thanks!
